### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -8,14 +8,14 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to DockerHub with version-tag
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: abuhamsa/xteve-lazystream
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         tag_names: true
     - name: Publish to DockerHub with latest-tag
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: abuhamsa/xteve-lazystream
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/github-docker-tag.yml
+++ b/.github/workflows/github-docker-tag.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to GitHub with version-tag
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: abuhamsa/xteve-lazystream
         username: ${{ github.actor }}
@@ -16,7 +16,7 @@ jobs:
         registry: ghcr.io
         tag_names: true  
     - name: Publish to GitHub with latest-tag
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: abuhamsa/xteve-lazystream
         username: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore